### PR TITLE
Added  missing MASFC patch to mk1inline.cfg

### DIFF
--- a/GameData/Reviva/Stock/mk1inline.cfg
+++ b/GameData/Reviva/Stock/mk1inline.cfg
@@ -17,6 +17,17 @@
 	}
 }
 
+@PART[Mark2Cockpit]:HAS[!MODULE[MASFlightComputer]]:NEEDS[DE_IVAExtension&AvionicsSystems]:FOR[zzz_Reviva]
+{
+    MODULE
+    {
+        name = MASFlightComputer
+        requiresPower = true
+        gLimit = 4.7
+        baseDisruptionChance = 0.20
+    }
+}
+
 @PART[Mark2Cockpit]:NEEDS[B9PartSwitch]:FOR[zzz_Reviva]
 {
 	@INTERNAL {


### PR DESCRIPTION
- Missing MASFlightComputer patch was causing MAS props not function in some DE_IVA Extensions IVAs. 
      - specifically the HUD prop in the DE+MAS IVAs
      
Turns out, its a MM patching order issue, also, between Reviva & MAS.
MAS needs some edits to its patches, to run as late as possible, since it *globally* adds MASFlightComputer to just about *everything*. So MAS will need fixing, and an update as well, in addition to this fix for Reviva, to "fix" this issue.